### PR TITLE
[WIP] セッションバックアップからログインできるように修正

### DIFF
--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		17D61FA7216BBC59009B2B9C /* AWSMobileClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D61FA6216BBC59009B2B9C /* AWSMobileClient.swift */; };
 		17DED2A61F32A4E400397F88 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1786CA4D1F2BEDB8003421FF /* Images.xcassets */; };
 		17F4F75121F6B0750068B553 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F4F74F21F6B0750068B553 /* AWSCognitoAuth+Extensions.m */; };
+		7E1D081826F9CA7F00F2D173 /* AWSMobileClientExtensions+Talknote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1D081726F9CA7F00F2D173 /* AWSMobileClientExtensions+Talknote.swift */; };
 		B402CD1F2580672F0020B83B /* _AWSMobileClient.h in Headers */ = {isa = PBXBuildFile; fileRef = B5FC69031FAFA1AA004790CB /* _AWSMobileClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B402CD202580672F0020B83B /* AWSCognitoAuth_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 177B8AD921E52C730051068F /* AWSCognitoAuth_Internal.h */; };
 		B402CD212580672F0020B83B /* AWSCognitoAuthUICKeyChainStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 177B8ADB21E52C730051068F /* AWSCognitoAuthUICKeyChainStore.h */; };
@@ -1345,6 +1346,7 @@
 		17F4F74E21F6B0750068B553 /* AWSCognitoAuth+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoAuth+Extensions.h"; sourceTree = "<group>"; };
 		17F4F74F21F6B0750068B553 /* AWSCognitoAuth+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoAuth+Extensions.m"; sourceTree = "<group>"; };
 		6BB7BF2E23E5E8FB0026E789 /* AWSMobileClient-Mixed-Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-Mixed-Swift.h"; sourceTree = "<group>"; };
+		7E1D081726F9CA7F00F2D173 /* AWSMobileClientExtensions+Talknote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSMobileClientExtensions+Talknote.swift"; sourceTree = "<group>"; };
 		B402CD3F2580672F0020B83B /* AWSMobileClientXCF.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSMobileClientXCF.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B402D00725815C550020B83B /* AWSMobileClientXCF.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSMobileClientXCF.h; sourceTree = "<group>"; };
 		B402D0D225815D690020B83B /* AWSMobileClientXCF-Mixed-Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClientXCF-Mixed-Swift.h"; sourceTree = "<group>"; };
@@ -2095,6 +2097,7 @@
 				1744D05A21FFD84E00A81008 /* DeviceOperations.swift */,
 				170AD35221921764004E1E88 /* AWSMobileClient.h */,
 				B402D00725815C550020B83B /* AWSMobileClientXCF.h */,
+				7E1D081726F9CA7F00F2D173 /* AWSMobileClientExtensions+Talknote.swift */,
 			);
 			path = AWSMobileClient;
 			sourceTree = "<group>";
@@ -3684,6 +3687,7 @@
 				B402CD2A2580672F0020B83B /* AWSMobileOptions.swift in Sources */,
 				B402CD2B2580672F0020B83B /* DeviceOperations.swift in Sources */,
 				B402CD2C2580672F0020B83B /* AWSUserPoolOperationsHandler.swift in Sources */,
+				7E1D081826F9CA7F00F2D173 /* AWSMobileClientExtensions+Talknote.swift in Sources */,
 				B402CD2D2580672F0020B83B /* AWSCognitoAuthUICKeyChainStore.m in Sources */,
 				B402CD2E2580672F0020B83B /* _AWSMobileClient.m in Sources */,
 				B402CD2F2580672F0020B83B /* AWSCognitoAuth+Extensions.m in Sources */,

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -512,8 +512,9 @@ final public class AWSMobileClient: _AWSMobileClient {
             })
         }
     }
-    
-    private func configureAndRegisterCognitoAuth(hostedUIOptions: HostedUIOptions,
+
+    // 20211002: to internal from private by kubota
+    internal func configureAndRegisterCognitoAuth(hostedUIOptions: HostedUIOptions,
                                                  _ completionHandler: @escaping(UserState?, Error?) -> Void) {
         loadOAuthURIQueryParametersFromKeychain()
         
@@ -601,8 +602,9 @@ final public class AWSMobileClient: _AWSMobileClient {
         AWSCognitoAuth.registerCognitoAuth(with: cognitoAuthConfig, forKey: CognitoAuthRegistrationKey)
         isCognitoAuthRegistered = true
     }
-    
-    private func handleCognitoAuthGetSession(hostedUIOptions: HostedUIOptions,
+
+    // 20211002: to internal from private by kubota
+    internal func handleCognitoAuthGetSession(hostedUIOptions: HostedUIOptions,
                                              session: AWSCognitoAuthUserSession?,
                                              error: Error?,
                                              _ completionHandler: @escaping(UserState?, Error?) -> Void) {

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions+Talknote.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions+Talknote.swift
@@ -1,0 +1,121 @@
+//
+//  AWSMobileClientExtensions+Talknote.swift
+//  AWSMobileClientXCF
+//
+//  Created by Daisuke Kubota on 2021/09/21.
+//  Copyright © 2021 Amazon Web Services. All rights reserved.
+//
+
+import Foundation
+
+extension AWSMobileClient {
+    public func getSessionBackup(completionHandler: @escaping ((String?, Error?) -> Void)) {
+        switch self.federationProvider {
+        case .userPools, .hostedUI:
+            break
+        default:
+            completionHandler(nil, AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
+            return
+        }
+        var map = [String: Any?]()
+        map["username"] = self.username
+        if (self.federationProvider == .userPools) {
+            map["federationProvider"] = "userPools"
+            self.currentUser?.getBackup().continueWith(block: { (task) -> Any? in
+                if let error = task.error {
+                    completionHandler(nil, error)
+                } else if let backup = task.result {
+                    map["data"] = backup
+                    do {
+                        let data = try JSONSerialization.data(withJSONObject: map)
+                        let str = String(data: data, encoding: .utf8)
+                        completionHandler(str, nil)
+                    } catch (let e) {
+                        completionHandler(nil, e)
+                    }
+                }
+                return nil
+            })
+        } else if (self.federationProvider == .hostedUI) {
+            map["federationProvider"] = "hostedUI"
+            print(cognitoAuthParameters)
+            AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey).getBackup { (result, error) in
+                if let error = error {
+                    completionHandler(nil, error)
+                } else if let backup = result {
+                    map["data"] = backup
+                    if let clientId = self.cognitoAuthParameters?.clientId {
+                        map["client_id"] = clientId
+                    }
+                    if let clientSecret = self.cognitoAuthParameters?.clientSecret {
+                        map["client_secret"] = clientSecret
+                    }
+                    do {
+                        let data = try JSONSerialization.data(withJSONObject: map)
+                        let str = String(data: data, encoding: .utf8)
+                        completionHandler(str, nil)
+                    } catch (let e) {
+                        completionHandler(nil, e)
+                    }
+                }
+            }
+        }
+    }
+
+    public func signInWithBackup(backup: String, completionHandler: @escaping ((UserState?, Error?) -> Void)) {
+        switch self.currentUserState {
+        case .signedIn:
+            completionHandler(nil, AWSMobileClientError.invalidState(message: "There is already a user which is signed in. Please log out the user before calling signIn."))
+            return
+        default:
+            break
+        }
+        guard let backupData = backup.data(using: .utf8) else {
+            completionHandler(nil, AWSMobileClientError.invalidState(message: ""))
+            return
+        }
+        do {
+            let backupJson = try JSONSerialization.jsonObject(with: backupData) as! Dictionary<String, Any?>
+            let federationProvider = backupJson["federationProvider"] as? String
+            if (federationProvider == "userPools") {
+                self.userpoolOpsHelper.userpoolClient?.delegate = self.userpoolOpsHelper
+                self.userpoolOpsHelper.authHelperDelegate = self
+                let user = self.userPoolClient?.getUser(backupJson["username"] as! String)
+                user!.getSession(backupJson["data"] as! Dictionary<String, String>).continueOnSuccessWith(block: { (task) -> Any? in
+                    if let error = task.error {
+                        self.invokeSignInCallback(signResult: nil, error: AWSMobileClientError.makeMobileClientError(from: error))
+                    } else if let result = task.result {
+                        self.internalCredentialsProvider?.clearCredentials()
+                        self.federationProvider = .userPools
+                        self.performUserPoolSuccessfulSignInTasks(session: result)
+                        let tokenString = result.idToken!.tokenString
+                        self.mobileClientStatusChanged(userState: .signedIn,
+                                                       additionalInfo: [self.ProviderKey:self.userPoolClient!.identityProviderName,
+                                                                        self.TokenKey:tokenString])
+                        self.invokeSignInCallback(signResult: SignInResult(signInState: .signedIn), error: nil)
+                    }
+                    return nil
+                })
+            } else if (federationProvider == "hostedUI") {
+                let hostedUIOptions = HostedUIOptions(
+                    parameters: CognitoAuthParameters(
+                        clientId: (backupJson["client_id"] as? String)!,
+                        clientSecret: backupJson["client_secret"] as? String
+                        )
+                )
+                configureAndRegisterCognitoAuth(
+                    hostedUIOptions: hostedUIOptions,
+                    completionHandler
+                )
+                let cognitoAuth = AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey)
+                cognitoAuth.delegate = self
+                cognitoAuth.signIn(withBackup: backupJson["data"] as! Dictionary<String, String>) { (session, error) in
+                    self.handleCognitoAuthGetSession(hostedUIOptions: hostedUIOptions, session: session, error: error, completionHandler)
+                }
+            }
+        } catch (let e) {
+            completionHandler(nil, AWSMobileClientError.invalidState(message: e.localizedDescription))
+        }
+
+    }
+}

--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSInteger, AWSCognitoAuthClientErrorType) {
 
 typedef void (^AWSCognitoAuthGetSessionBlock)(AWSCognitoAuthUserSession * _Nullable session, NSError * _Nullable error);
 typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
-
+typedef void (^AWSCognitoAuthGetBackupBlock)(NSDictionary<NSString *, NSString *> * _Nullable backup, NSError * _Nullable error);
 
 /**
  A lightweight web-based ui to manage signup/signin of your end users
@@ -176,6 +176,10 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options;
 
+
+- (void) signInWithBackup: (NSDictionary<NSString *, NSString *> *) backup completion: (nullable AWSCognitoAuthGetSessionBlock) completion;
+
+- (void) getBackup: (nullable AWSCognitoAuthGetBackupBlock) completion;
 
 @end
 

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -274,6 +274,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (AWSTask *) forgetDevice;
 
 
+/**
+ Get backup dictionary
+ 2021/09/18 by Daisuke Kubota
+ */
+- (AWSTask<NSDictionary<NSString *, NSString *> *> *) getBackup;
+
+/**
+ Get Session with backup
+ */
+- (AWSTask<AWSCognitoIdentityUserSession *> *) getSession: (NSDictionary<NSString *, NSString *> *) backup;
+
 @end
 
 


### PR DESCRIPTION
* AWSMobileClient.default().getSessionBackup(completionHandler: @escaping ((String?, Error?) -> Void))でセッションバックアップの取得実装
* AWSMobileClient.default().signInWithBackup(backup: String, completionHandler: @escaping ((UserState?, Error?) -> Void))でセッションバックアップからログイン実装
* 通常ログイン(UserPools)とSAML(HostedUI)対応