### PR TITLE
[TSD-4487] aws-sdk-iosを修正する

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -72,4 +72,22 @@ extension AWSMobileClient {
         }
     }
 
+    // added 20200605 by kubota
+    // for Talknote SAML
+    internal func saveHostedUIOptionsCognitoAuthParameters() {
+        self.keychain.setData(
+            JSONHelper.dataFromDictionary(self.cognitoAuthParameters?.toDictionary()),
+            forKey: AWSMobileClientConstants.HostedUIOptionsCognitoAuthParametersKey
+        )
+    }
+
+    internal func loadHostedUIOptionsCognitoAuthParameters() {
+        self.cognitoAuthParameters = CognitoAuthParameters(
+            dict: JSONHelper.dictionaryFromData(self.keychain.data(forKey: AWSMobileClientConstants.HostedUIOptionsCognitoAuthParametersKey))
+        )
+    }
+
+    internal func clearHostedUIOptionsCognitoAuthParameters() {
+        self.keychain.removeItem(forKey: AWSMobileClientConstants.HostedUIOptionsCognitoAuthParametersKey)
+    }
 }

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -36,7 +36,16 @@ extension AWSMobileClient {
     /// Note that the value stored may vary depending on how sign-in was performed.
     /// @see https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html#amazon-cognito-user-pools-using-the-access-token
     public var username: String? {
-        return self.userpoolOpsHelper?.currentActiveUser?.username
+        if let _username = self.userpoolOpsHelper?.currentActiveUser?.username {
+            return _username
+        }
+        // SAMLログイン時はuserpoolOpsHelper?.currentActiveUserがusernameを持っていないのでAWSCognitoAuthからusernameを取得するようにする
+        // (SAMLログイン限定で)ここを外すとアプリ再起動でログアウトされる、トークン取得ができない事象あり。  2023.12.28 kim
+        if case .hostedUI = self.federationProvider {
+            let cognitoAuth = AWSCognitoAuth(forKey: AWSMobileClientConstants.CognitoAuthRegistrationKey)
+            return cognitoAuth.currentUsername()
+        }
+        return nil
     }
 
     public var userSub: String? {

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+SignInUI.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+SignInUI.swift
@@ -169,6 +169,9 @@ extension AWSMobileClient {
         if hostedUIOptions.scopes != nil {
             self.saveHostedUIOptionsScopesInKeychain()
         }
+        if hostedUIOptions.parameters != nil {
+            self.saveHostedUIOptionsCognitoAuthParameters()
+        }
         let federationProviderIdentifier = hostedUIOptions.federationProviderName
 
         self.performHostedUISuccessfulSignInTasks(disableFederation: hostedUIOptions.disableFederation, session: session, federationToken: federationToken!, federationProviderIdentifier: federationProviderIdentifier, signInInfo: &signInInfo)
@@ -198,8 +201,16 @@ extension AWSMobileClient {
         let infoDictionaryMobileClient = AWSInfo.default().rootInfoDictionary["Auth"] as? [String: [String: Any]]
         let infoDictionary: [String: Any]? = infoDictionaryMobileClient?["Default"]?["OAuth"] as? [String: Any]
 
-        let clientId = infoDictionary?["AppClientId"] as? String
-        let secret = infoDictionary?["AppClientSecret"] as? String
+        var clientId = infoDictionary?["AppClientId"] as? String
+        var secret = infoDictionary?["AppClientSecret"] as? String
+
+        self.cognitoAuthParameters = hostedUIOptions.parameters
+        if self.cognitoAuthParameters != nil {
+            clientId = self.cognitoAuthParameters?.clientId
+            secret = self.cognitoAuthParameters?.clientSecret
+        } else {
+            clearHostedUIOptionsCognitoAuthParameters()
+        }
         let webDomain = infoDictionary?["WebDomain"] as? String
         let hostURL = "https://\(webDomain!)"
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+Tokens.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+Tokens.swift
@@ -73,7 +73,13 @@ extension AWSMobileClient: FetchUserPoolTokensDelegate {
     }
 
     func getCurrentUsername(operation: FetchUserPoolTokensOperation) -> String? {
-        username
+        // このdelegate関数はトークン取得時のみ呼ばれ、saml認証ではCognitoIdentityUserBehavior取得時usernameが使われない模様。
+        // ただusernameがないとTokenが取得される前に弾かれるので、saml認証の場合、AWSCognitoAuthからのusernameを返すようにしている   2022.11.25 kim
+        if case .hostedUI = self.federationProvider, username == nil {
+            let cognitoAuth = AWSCognitoAuth(forKey: AWSMobileClientConstants.CognitoAuthRegistrationKey)
+            return cognitoAuth.currentUsername()
+        }
+        return username
     }
 
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+Tokens.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+Tokens.swift
@@ -73,13 +73,7 @@ extension AWSMobileClient: FetchUserPoolTokensDelegate {
     }
 
     func getCurrentUsername(operation: FetchUserPoolTokensOperation) -> String? {
-        // このdelegate関数はトークン取得時のみ呼ばれ、saml認証ではCognitoIdentityUserBehavior取得時usernameが使われない模様。
-        // ただusernameがないとTokenが取得される前に弾かれるので、saml認証の場合、AWSCognitoAuthからのusernameを返すようにしている   2022.11.25 kim
-        if case .hostedUI = self.federationProvider, username == nil {
-            let cognitoAuth = AWSCognitoAuth(forKey: AWSMobileClientConstants.CognitoAuthRegistrationKey)
-            return cognitoAuth.currentUsername()
-        }
-        return username
+        username
     }
 
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/Helpers/AWSMobileClientConstants.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Helpers/AWSMobileClientConstants.swift
@@ -31,6 +31,7 @@ struct AWSMobileClientConstants {
     static let FederationDisabledKey = "federationDisabled"
     static let HostedUIOptionsScopesKey = "hostedUIOptionsScopes"
     static let ConfigurationKey = "configurationKey"
+    static let HostedUIOptionsCognitoAuthParametersKey: String = "hostedUIOptionsCognitoAuthParametersKey"
     static let CognitoAuthRegistrationKey = "AWSMobileClient"
     
     static let notSignedInMessage = """

--- a/AWSAuthSDK/Sources/AWSMobileClient/Models/HostedUIOptions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Models/HostedUIOptions.swift
@@ -20,6 +20,7 @@ import Foundation
 /// NOTE: If specified, some of the values in this type will override the corresponding values in `awsconfiguration.json`. See
 /// the `init` method below.
 public struct HostedUIOptions {
+    let parameters: CognitoAuthParameters?
     let scopes: [String]?
 
     let identityProvider: String?
@@ -38,6 +39,7 @@ public struct HostedUIOptions {
     ///
     /// - Parameters:
     ///   - disableFederation: If set to true, will not federate with Cognito Identity service to fetch AWSCredentials. `true` by default.
+    ///   - parameters: for Talknote
     ///   - scopes: The scopes for the current login session. If specified here, the scopes specified in `awsconfiguration.json` would be over-ridden.
     ///   - identityProvider: The IdentityProvider to be used for hosted UI. If using Cognito UserPools it could be `Google`, `Facebook`, etc.
     ///   - idpIdentifier: The IdentityProvider identifier if using multiple instances of same identity provider.
@@ -46,6 +48,7 @@ public struct HostedUIOptions {
     ///   - tokenURIQueryParameters: The additional query parameters apart from standard OAuth w/ open id connect parameters for tokenURI. If specified here, the tokenURIQueryParameters specified in `awsconfiguration.json` would be over-ridden.
     ///   - signOutURIQueryParameters: The additional query parameters apart from standard OAuth w/ open id connect parameters for signOutURI. If specified here, the signOutURIQueryParameters specified in `awsconfiguration.json` would be over-ridden.
     public init(disableFederation: Bool = false,
+                parameters: CognitoAuthParameters? = nil,
                 scopes: [String]? = nil,
                 identityProvider: String? = nil,
                 idpIdentifier: String? = nil,
@@ -72,5 +75,36 @@ public struct HostedUIOptions {
         self.tokenURIQueryParameters = tokenURIQueryParameters
         self.signOutURIQueryParameters = signOutURIQueryParameters
         self.signInPrivateSession = signInPrivateSession
+        self.parameters = parameters
+    }
+}
+
+/// for Talknote SAML
+/// added 20200605
+/// by kubota
+public struct CognitoAuthParameters {
+    private let clientIdKey = "AppClientId"
+    private let clientSecretKey = "AppClientSecret"
+
+    let clientId: String
+    let clientSecret: String?
+
+    public init(clientId: String,
+                clientSecret: String? = nil) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+    }
+
+    public init?(dict: [String: String]?) {
+        guard let dict = dict, let clientId = dict[clientIdKey] else { return nil }
+        self.clientId = clientId
+        self.clientSecret = dict[clientSecretKey]
+    }
+
+    internal func toDictionary() -> [String: String] {
+        return [
+            clientIdKey: clientId,
+            clientSecretKey: clientSecret,
+        ].compactMapValues { $0 }
     }
 }

--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -176,6 +176,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options;
 
+- (NSString *)currentUsername;
 
 @end
 

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -112,6 +112,9 @@ static NSString *const AWSCognitoAuthUseSFAuthSession = @"EnableSFAuthentication
 static NSString *const AWSCognitoAuthUnknown = @"Unknown";
 static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
 
+static NSString *const AWSCognitoAuthKeychain = @"Keychain";
+static NSString *const AWSCognitoAuthKeychainService = @"Service";
+static NSString *const AWSCognitoAuthKeychainAccessGroup = @"AccessGroup";
 
 #pragma mark init and configuration
 
@@ -199,7 +202,10 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
 
         _useSFAuthenticationSession = authConfiguration.isSFAuthenticationSessionEnabled;
         _sfAuthenticationSessionAvailable = NO;
-        _keychain = [AWSCognitoAuthUICKeyChainStore keyChainStoreWithService:[NSString stringWithFormat:@"%@.%@", [NSBundle mainBundle].bundleIdentifier, @"AWSCognitoIdentityUserPool"]];  //Consistent with AWSCognitoIdentityUserPool
+        NSDictionary *keychainInfo = [[AWSInfo defaultAWSInfo] rootInfoDictionary][AWSCognitoAuthKeychain];
+        NSString *service = keychainInfo[AWSCognitoAuthKeychainService];
+        NSString *accessGroup = keychainInfo[AWSCognitoAuthKeychainAccessGroup];
+        _keychain = [AWSCognitoAuthUICKeyChainStore keyChainStoreWithService:service accessGroup:accessGroup];  //Consistent with AWSCognitoIdentityUserPool
         [_keychain migrateToCurrentAccessibility];
     }
     return self;

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
@@ -115,6 +115,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSString *pinpointAppId;
 @property (nonatomic, readonly) BOOL shouldProvideCognitoValidationData;
 @property (nonatomic, readonly) BOOL migrationEnabled;
+@property (nonatomic, readonly, nullable) NSString *keychainService;
+@property (nonatomic, readonly, nullable) NSString *keychainAccessGroup;
 
 - (instancetype)initWithClientId:(NSString *)clientId
                     clientSecret:(nullable NSString *)clientSecret
@@ -138,6 +140,14 @@ shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
                    pinpointAppId:(nullable NSString *)pinpointAppId
                 migrationEnabled:(BOOL) migrationEnabled;
 
+- (instancetype)initWithClientId:(NSString *)clientId
+                    clientSecret:(nullable NSString *)clientSecret
+                          poolId:(NSString *)poolId
+shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
+                   pinpointAppId:(nullable NSString *)pinpointAppId
+                migrationEnabled:(BOOL) migrationEnabled
+                 keychainService:(nullable NSString *)keychainService
+             keychainAccessGroup:(nullable NSString *)keychainAccessGroup;
 @end
 
 /**

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
@@ -49,6 +49,10 @@ static NSString *const AWSCognitoUserPoolEndpoint = @"Endpoint";
 static NSString *const AWSPinpointContextKeychainService = @"com.amazonaws.AWSPinpointContext";
 static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.AWSPinpointContextKeychainUniqueIdKey";
 
+static NSString *const AWSKeychain = @"Keychain";
+static NSString *const AWSKeychainService = @"Service";
+static NSString *const AWSKeychainAccessGroup = @"AccessGroup";
+
 + (void)loadCategories {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -129,6 +133,8 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
     NSString *clientSecret = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientSecret] ?: [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientSecretLegacy];
     NSString *pinpointAppId = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolPinpointAppId];
     NSNumber *migrationEnabled = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolMigrationEnabled];
+    NSString *keychainService = [[[AWSInfo defaultAWSInfo].rootInfoDictionary objectForKey:AWSKeychain] objectForKey:AWSKeychainService];
+    NSString *keychainAccessGroup = [[[AWSInfo defaultAWSInfo].rootInfoDictionary objectForKey:AWSKeychain] objectForKey:AWSKeychainAccessGroup];
 
     BOOL migrationEnabledBoolean = NO;
     if (migrationEnabled != nil) {
@@ -146,7 +152,9 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
                                                                       poolId:poolId
                                           shouldProvideCognitoValidationData:YES
                                                                pinpointAppId:pinpointAppId
-                                                            migrationEnabled:migrationEnabledBoolean ];
+                                                            migrationEnabled:migrationEnabledBoolean
+                                                             keychainService:keychainService
+                                                         keychainAccessGroup:keychainAccessGroup];
 
 }
 
@@ -170,7 +178,15 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
         _client = [[AWSCognitoIdentityProvider alloc] initWithConfiguration:_configuration];
         _userPoolConfiguration = userPoolConfiguration;
 
-        _keychain = [AWSUICKeyChainStore keyChainStoreWithService:[NSString stringWithFormat:@"%@.%@", [NSBundle mainBundle].bundleIdentifier, [AWSCognitoIdentityUserPool class]]];
+        NSString *identifier;
+        if (userPoolConfiguration.keychainService) {
+            identifier = userPoolConfiguration.keychainService;
+        } else {
+            identifier = [NSBundle mainBundle].bundleIdentifier;
+        }
+
+        _keychain = [AWSUICKeyChainStore keyChainStoreWithService:[NSString stringWithFormat:@"%@.%@", identifier, [AWSCognitoIdentityUserPool class]]
+                                                      accessGroup:userPoolConfiguration.keychainAccessGroup];
         [_keychain migrateToCurrentAccessibility];
         
         //If Pinpoint is setup, get the endpoint or create one.
@@ -457,6 +473,25 @@ shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
                    pinpointAppId:(nullable NSString *)pinpointAppId
                 migrationEnabled:(BOOL)migrationEnabled
 {
+    return [self initWithClientId:clientId
+                     clientSecret:clientSecret
+                           poolId:poolId
+shouldProvideCognitoValidationData:shouldProvideCognitoValidationData
+                    pinpointAppId:pinpointAppId
+                 migrationEnabled:migrationEnabled
+                  keychainService:nil
+              keychainAccessGroup:nil];
+}
+
+- (instancetype)initWithClientId:(NSString *)clientId
+                    clientSecret:(nullable NSString *)clientSecret
+                          poolId:(NSString *)poolId
+shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
+                   pinpointAppId:(nullable NSString *)pinpointAppId
+                migrationEnabled:(BOOL)migrationEnabled
+                 keychainService:(nullable NSString *)keychainService
+             keychainAccessGroup:(nullable NSString *)keychainAccessGroup
+{
     if (self = [super init]) {
         _clientId = clientId;
         _clientSecret = clientSecret;
@@ -464,8 +499,10 @@ shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
         _shouldProvideCognitoValidationData = shouldProvideCognitoValidationData;
         _pinpointAppId = pinpointAppId;
         _migrationEnabled = migrationEnabled;
+        _keychainService = keychainService;
+        _keychainAccessGroup = keychainAccessGroup;
     }
-    
+
     return self;
 }
 
@@ -475,7 +512,9 @@ shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
                                                                                                           poolId:self.poolId
                                                                               shouldProvideCognitoValidationData:self.shouldProvideCognitoValidationData
                                                                                                    pinpointAppId:self.pinpointAppId
-                                                                                                migrationEnabled:self.migrationEnabled];
+                                                                                                migrationEnabled:self.migrationEnabled
+                                                                                                 keychainService:self.keychainService
+                                                                                             keychainAccessGroup:self.keychainAccessGroup];
     return configuration;
 }
 

--- a/AWSCore/Authentication/AWSCredentialsProvider.h
+++ b/AWSCore/Authentication/AWSCredentialsProvider.h
@@ -192,6 +192,11 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderErrorType) {
 - (instancetype)initWithRegionType:(AWSRegionType)regionType
                     identityPoolId:(NSString *)identityPoolId;
 
+- (instancetype)initWithRegionType:(AWSRegionType)regionType
+                    identityPoolId:(NSString *)identityPoolId
+                   keychainService:(nullable NSString *)keychainService
+               keychainAccessGroup:(nullable NSString *)keychainAccessGroup;
+
 /**
 Initializer for credentials provider with enhanced authentication flow. This is the recommended constructor for first time Amazon Cognito developers. Will create an instance of `AWSEnhancedCognitoIdentityProvider`.
 
@@ -213,6 +218,12 @@ Initializer for credentials provider with enhanced authentication flow. This is 
 - (instancetype)initWithRegionType:(AWSRegionType)regionType
                     identityPoolId:(NSString *)identityPoolId
            identityProviderManager:(nullable id<AWSIdentityProviderManager>)identityProviderManager;
+
+- (instancetype)initWithRegionType:(AWSRegionType)regionType
+                    identityPoolId:(NSString *)identityPoolId
+           identityProviderManager:(nullable id<AWSIdentityProviderManager>)identityProviderManager
+                   keychainService:(nullable NSString *)keychainService
+               keychainAccessGroup:(nullable NSString *)keychainAccessGroup;
 
 /**
  Initializer for credentials provider with pre-created `AWSCognitoCredentialsProviderHelper`. Use this method when using developer authenticated identities.

--- a/AWSCore/Authentication/AWSCredentialsProvider.m
+++ b/AWSCore/Authentication/AWSCredentialsProvider.m
@@ -329,6 +329,8 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
                  identityProvider:identityProvider
                     unauthRoleArn:nil
                       authRoleArn:nil
+                  keychainService:nil
+              keychainAccessGroup:nil
         identityPoolConfiguration:configuration];
     }
 
@@ -345,6 +347,26 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
 
 - (instancetype)initWithRegionType:(AWSRegionType)regionType
                     identityPoolId:(NSString *)identityPoolId
+                   keychainService:(NSString *)keychainService
+               keychainAccessGroup:(NSString *)keychainAccessGroup {
+    if (self = [super init]) {
+        AWSCognitoCredentialsProviderHelper *identityProvider = [[AWSCognitoCredentialsProviderHelper alloc] initWithRegionType:regionType
+                                                                                                                 identityPoolId:identityPoolId
+                                                                                                                useEnhancedFlow:YES
+                                                                                                        identityProviderManager:nil];
+        [self setUpWithRegionType:regionType
+                 identityProvider:identityProvider
+                    unauthRoleArn:nil
+                      authRoleArn:nil
+                  keychainService:keychainService
+              keychainAccessGroup:keychainAccessGroup];
+    }
+
+    return self;
+}
+
+- (instancetype)initWithRegionType:(AWSRegionType)regionType
+                    identityPoolId:(NSString *)identityPoolId
            identityProviderManager:(nullable id<AWSIdentityProviderManager>)identityProviderManager {
     if (self = [super init]) {
         AWSCognitoCredentialsProviderHelper *identityProvider = [[AWSCognitoCredentialsProviderHelper alloc] initWithRegionType:regionType
@@ -354,7 +376,30 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
         [self setUpWithRegionType:regionType
                  identityProvider:identityProvider
                     unauthRoleArn:nil
-                      authRoleArn:nil];
+                      authRoleArn:nil
+                  keychainService:nil
+              keychainAccessGroup:nil];
+    }
+
+    return self;
+}
+
+- (instancetype)initWithRegionType:(AWSRegionType)regionType
+                    identityPoolId:(NSString *)identityPoolId
+           identityProviderManager:(id<AWSIdentityProviderManager>)identityProviderManager
+                   keychainService:(NSString *)keychainService
+               keychainAccessGroup:(NSString *)keychainAccessGroup {
+    if (self = [super init]) {
+        AWSCognitoCredentialsProviderHelper *identityProvider = [[AWSCognitoCredentialsProviderHelper alloc] initWithRegionType:regionType
+                                                                                                                 identityPoolId:identityPoolId
+                                                                                                                useEnhancedFlow:YES
+                                                                                                        identityProviderManager:identityProviderManager];
+        [self setUpWithRegionType:regionType
+                 identityProvider:identityProvider
+                    unauthRoleArn:nil
+                      authRoleArn:nil
+                  keychainService:keychainService
+              keychainAccessGroup:keychainAccessGroup];
     }
 
     return self;
@@ -366,7 +411,10 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
         [self setUpWithRegionType:regionType
                  identityProvider:identityProvider
                     unauthRoleArn:nil
-                      authRoleArn:nil];
+                      authRoleArn:nil
+                  keychainService:nil 
+              keychainAccessGroup:nil
+        ];
     }
 
     return self;
@@ -380,7 +428,10 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
         [self setUpWithRegionType:regionType
                  identityProvider:identityProvider
                     unauthRoleArn:unauthRoleArn
-                      authRoleArn:authRoleArn];
+                      authRoleArn:authRoleArn
+                  keychainService:nil
+              keychainAccessGroup:nil
+        ];
     }
 
     return self;
@@ -399,7 +450,10 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
         [self setUpWithRegionType:regionType
                  identityProvider:identityProvider
                     unauthRoleArn:unauthRoleArn
-                      authRoleArn:authRoleArn];
+                      authRoleArn:authRoleArn
+                  keychainService:nil
+              keychainAccessGroup:nil
+        ];
     }
 
     return self;
@@ -409,6 +463,8 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
            identityProvider:(id<AWSCognitoCredentialsProviderHelper>)identityProvider
               unauthRoleArn:(NSString *)unauthRoleArn
                 authRoleArn:(NSString *)authRoleArn
+            keychainService:(NSString *)keychainService
+        keychainAccessGroup:(NSString *)keychainAccessGroup
   identityPoolConfiguration:(AWSServiceConfiguration *)configuration {
     _refreshExecutor = [AWSExecutor executorWithOperationQueue:[NSOperationQueue new]];
     _refreshingCredentials = NO;
@@ -420,7 +476,14 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     _useEnhancedFlow = !unauthRoleArn && !authRoleArn;
 
     // initialize keychain - name spaced by app bundle and identity pool id
-    _keychain = [AWSUICKeyChainStore keyChainStoreWithService:[NSString stringWithFormat:@"%@.%@.%@", [NSBundle mainBundle].bundleIdentifier, [AWSCognitoCredentialsProvider class], identityProvider.identityPoolId]];
+    NSString *keyChainStoreService;
+    if (!keychainService) {
+        keyChainStoreService = [NSString stringWithFormat:@"%@.%@.%@", [NSBundle mainBundle].bundleIdentifier, [AWSCognitoCredentialsProvider class], identityProvider.identityPoolId];
+    } else {
+        keyChainStoreService = [NSString stringWithFormat:@"%@.%@.%@", keychainService, [AWSCognitoCredentialsProvider class], identityProvider.identityPoolId];
+    }
+    _keychain = [AWSUICKeyChainStore keyChainStoreWithService:keyChainStoreService
+                                                  accessGroup:keychainAccessGroup];
     [_keychain migrateToCurrentAccessibility];
     
     // If the identity provider has an identity id, use it
@@ -445,7 +508,9 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
 - (void)setUpWithRegionType:(AWSRegionType)regionType
            identityProvider:(id<AWSCognitoCredentialsProviderHelper>)identityProvider
               unauthRoleArn:(NSString *)unauthRoleArn
-                authRoleArn:(NSString *)authRoleArn {
+                authRoleArn:(NSString *)authRoleArn
+            keychainService:(NSString *)keychainService
+        keychainAccessGroup:(NSString *)keychainAccessGroup {
     AWSAnonymousCredentialsProvider *credentialsProvider = [AWSAnonymousCredentialsProvider new];
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:regionType
                                                                          credentialsProvider:credentialsProvider];
@@ -453,6 +518,8 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
              identityProvider:identityProvider
                 unauthRoleArn:unauthRoleArn
                   authRoleArn:authRoleArn
+              keychainService:keychainService
+          keychainAccessGroup:keychainAccessGroup
     identityPoolConfiguration:configuration];
 }
 

--- a/AWSCore/Service/AWSInfo.m
+++ b/AWSCore/Service/AWSInfo.m
@@ -30,6 +30,10 @@ static NSString *const AWSInfoCognitoUserPool = @"CognitoUserPool";
 
 static NSString *const AWSInfoIdentityManager = @"IdentityManager";
 
+static NSString *const AWSInfoKeychain = @"Keychain";
+static NSString *const AWSInfoKeychainService = @"Service";
+static NSString *const AWSInfoKeychainAccessGroup = @"AccessGroup";
+
 @interface AWSInfo()
 
 @property (nonatomic, strong) AWSCognitoCredentialsProvider *defaultCognitoCredentialsProvider;
@@ -69,10 +73,15 @@ static AWSServiceConfiguration *_identityPoolConfiguration = nil;
         NSDictionary <NSString *, id> *defaultCredentialsProviderDictionary = [[[_rootInfoDictionary objectForKey:AWSInfoCredentialsProvider] objectForKey:AWSInfoCognitoIdentity] objectForKey:AWSInfoDefault];
         NSString *cognitoIdentityPoolID = [defaultCredentialsProviderDictionary objectForKey:AWSInfoCognitoIdentityPoolId];
         AWSRegionType cognitoIdentityRegion =  [[defaultCredentialsProviderDictionary objectForKey:AWSInfoRegion] aws_regionTypeValue];
+        NSDictionary <NSString *, id> *defaultKeychainDictionary = [_rootInfoDictionary objectForKey:AWSInfoKeychain];
+        NSString *keychainService = [defaultKeychainDictionary objectForKey:AWSInfoKeychainService];
+        NSString *keychainAccessGroup = [defaultKeychainDictionary objectForKey:AWSInfoKeychainAccessGroup];
         if (cognitoIdentityPoolID && cognitoIdentityRegion != AWSRegionUnknown) {
             if (_identityPoolConfiguration == nil) {
                 _defaultCognitoCredentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:cognitoIdentityRegion
-                                                                                                           identityPoolId:cognitoIdentityPoolID];
+                                                                                                           identityPoolId:cognitoIdentityPoolID
+                                                                                               keychainService:keychainService
+                                                                                           keychainAccessGroup:keychainAccessGroup];
             } else {
                 _defaultCognitoCredentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:cognitoIdentityRegion
                                                                                                            identityPoolId:cognitoIdentityPoolID


### PR DESCRIPTION
https://talknote-dev.atlassian.net/browse/TSD-4487
## 対応内容
- aws-sdk-iosの2.33.7のタグからブランチを切って既存の修正箇所と同じ箇所を修正しています。 https://github.com/talknote-inc/aws-sdk-ios/commit/97d8aa7dfd1d3dc7ee54bd39a36f9c8ff9f04074
- saml認証下でusernameが取得できないとアプリ再起動でログインが外れる事象があり、username取得周りを見直しています。 https://github.com/talknote-inc/aws-sdk-ios/commit/d6a78ad5ef7ca61e5db82e5564bca975ca301328
  - 修正箇所のusernameは以下の場面で参照されます。
    - トークン取得時
    - アプリ起動時（signedInチェック）
## 動作確認
### 通常ログイン
- [x] ログインできること
- [x] アプリのアップデートでログイン状態が維持されること
- [x] 複数のアカウントでログインできること
- [x] アカウントの切り替えができること
- [x] IoT経由で新しい投稿のお知らせや新しいメッセージが届くこと
- [x] 投稿で写真及び、動画、ファイルが投稿できること
- [x] シェアエクステンションで写真及び、動画、ファイルが投稿できること
### SAMLログイン
- [x] ログインできること
- [x] アプリのアップデートでログイン状態が維持されること
- [x] IoT経由で新しい投稿のお知らせや新しいメッセージが届くこと
- [x] 投稿で写真及び、動画、ファイルが投稿できること
- [x] シェアエクステンションで写真及び、動画、ファイルが投稿できること